### PR TITLE
first pass at the end status rpc implementation. need to switch devic…

### DIFF
--- a/ai-server/rpc/generated/naila_pb2.py
+++ b/ai-server/rpc/generated/naila_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0bnaila.proto\x12\x05naila\"\x9e\x02\n\nAudioInput\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12\x0f\n\x07room_id\x18\x02 \x01(\t\x12\x17\n\x0f\x63onversation_id\x18\x03 \x01(\t\x12\x13\n\taudio_pcm\x18\x04 \x01(\x0cH\x00\x12\x14\n\naudio_opus\x18\x05 \x01(\x0cH\x00\x12 \n\x05\x63odec\x18\x06 \x01(\x0e\x32\x11.naila.AudioCodec\x12\x13\n\x0bsample_rate\x18\x07 \x01(\r\x12\x19\n\x11\x63hunk_duration_ms\x18\x08 \x01(\r\x12\x14\n\x0ctimestamp_ms\x18\t \x01(\x04\x12\x14\n\x0csequence_num\x18\n \x01(\r\x12!\n\x05\x65vent\x18\x0b \x01(\x0e\x32\x12.naila.SpeechEventB\x07\n\x05\x61udio\"\xea\x01\n\x0b\x41udioOutput\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12\x0f\n\x07room_id\x18\x02 \x01(\t\x12\x17\n\x0f\x63onversation_id\x18\x03 \x01(\t\x12\x11\n\taudio_pcm\x18\x04 \x01(\x0c\x12\x13\n\x0bsample_rate\x18\x05 \x01(\r\x12\x14\n\x0csequence_num\x18\x06 \x01(\r\x12\x10\n\x08is_final\x18\x07 \x01(\x08\x12\x11\n\tfinal_stt\x18\x08 \x01(\t\x12$\n\nerror_code\x18\t \x01(\x0e\x32\x10.naila.ErrorCode\x12\x15\n\rerror_message\x18\n \x01(\t*V\n\nAudioCodec\x12\x17\n\x13\x41UDIO_CODEC_UNKNOWN\x10\x00\x12\x19\n\x15\x41UDIO_CODEC_PCM_S16LE\x10\x01\x12\x14\n\x10\x41UDIO_CODEC_OPUS\x10\x02*\x8c\x01\n\x0bSpeechEvent\x12\x18\n\x14SPEECH_EVENT_UNKNOWN\x10\x00\x12\x16\n\x12SPEECH_EVENT_START\x10\x01\x12\x19\n\x15SPEECH_EVENT_CONTINUE\x10\x02\x12\x14\n\x10SPEECH_EVENT_END\x10\x03\x12\x1a\n\x16SPEECH_EVENT_INTERRUPT\x10\x04*q\n\tErrorCode\x12\x0e\n\nERROR_NONE\x10\x00\x12\x14\n\x10\x45RROR_STT_FAILED\x10\x01\x12\x14\n\x10\x45RROR_LLM_FAILED\x10\x02\x12\x14\n\x10\x45RROR_TTS_FAILED\x10\x03\x12\x12\n\x0e\x45RROR_INTERNAL\x10\x63\x32J\n\x07NailaAI\x12?\n\x12StreamConversation\x12\x11.naila.AudioInput\x1a\x12.naila.AudioOutput(\x01\x30\x01\x42\x02H\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0bnaila.proto\x12\x05naila\"\x9e\x02\n\nAudioInput\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12\x0f\n\x07room_id\x18\x02 \x01(\t\x12\x17\n\x0f\x63onversation_id\x18\x03 \x01(\t\x12\x13\n\taudio_pcm\x18\x04 \x01(\x0cH\x00\x12\x14\n\naudio_opus\x18\x05 \x01(\x0cH\x00\x12 \n\x05\x63odec\x18\x06 \x01(\x0e\x32\x11.naila.AudioCodec\x12\x13\n\x0bsample_rate\x18\x07 \x01(\r\x12\x19\n\x11\x63hunk_duration_ms\x18\x08 \x01(\r\x12\x14\n\x0ctimestamp_ms\x18\t \x01(\x04\x12\x14\n\x0csequence_num\x18\n \x01(\r\x12!\n\x05\x65vent\x18\x0b \x01(\x0e\x32\x12.naila.SpeechEventB\x07\n\x05\x61udio\"\xea\x01\n\x0b\x41udioOutput\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12\x0f\n\x07room_id\x18\x02 \x01(\t\x12\x17\n\x0f\x63onversation_id\x18\x03 \x01(\t\x12\x11\n\taudio_pcm\x18\x04 \x01(\x0c\x12\x13\n\x0bsample_rate\x18\x05 \x01(\r\x12\x14\n\x0csequence_num\x18\x06 \x01(\r\x12\x10\n\x08is_final\x18\x07 \x01(\x08\x12\x11\n\tfinal_stt\x18\x08 \x01(\t\x12$\n\nerror_code\x18\t \x01(\x0e\x32\x10.naila.ErrorCode\x12\x15\n\rerror_message\x18\n \x01(\t\"D\n\rStatusRequest\x12\x1a\n\x12include_model_info\x18\x01 \x01(\x08\x12\x17\n\x0finclude_metrics\x18\x02 \x01(\x08\"\xd6\x03\n\x0eStatusResponse\x12#\n\x06health\x18\x01 \x01(\x0e\x32\x13.naila.ServerHealth\x12\x16\n\x0eserver_version\x18\x02 \x01(\t\x12\x16\n\x0euptime_seconds\x18\x03 \x01(\x04\x12\x31\n\x16supported_input_codecs\x18\x04 \x03(\x0e\x32\x11.naila.AudioCodec\x12\x32\n\x17supported_output_codecs\x18\x05 \x03(\x0e\x32\x11.naila.AudioCodec\x12\x1e\n\x16max_concurrent_streams\x18\x06 \x01(\r\x12#\n\tstt_model\x18\x07 \x01(\x0b\x32\x10.naila.ModelInfo\x12#\n\tllm_model\x18\x08 \x01(\x0b\x32\x10.naila.ModelInfo\x12#\n\ttts_model\x18\t \x01(\x0b\x32\x10.naila.ModelInfo\x12&\n\x0cvision_model\x18\n \x01(\x0b\x32\x10.naila.ModelInfo\x12%\n\x07metrics\x18\x0b \x01(\x0b\x32\x14.naila.ServerMetrics\x12*\n\ncomponents\x18\x0c \x03(\x0b\x32\x16.naila.ComponentHealth\"N\n\tModelInfo\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0e\n\x06loaded\x18\x03 \x01(\x08\x12\x0e\n\x06\x64\x65vice\x18\x04 \x01(\t\"\xad\x01\n\rServerMetrics\x12\x16\n\x0e\x61\x63tive_streams\x18\x01 \x01(\r\x12\x17\n\x0f\x63pu_utilization\x18\x02 \x01(\x02\x12\x1a\n\x12memory_utilization\x18\x03 \x01(\x02\x12\x17\n\x0fgpu_utilization\x18\x04 \x01(\x02\x12\x1e\n\x16gpu_memory_utilization\x18\x05 \x01(\x02\x12\x16\n\x0e\x61vg_latency_ms\x18\x06 \x01(\r\"U\n\x0f\x43omponentHealth\x12\x0c\n\x04name\x18\x01 \x01(\t\x12#\n\x06health\x18\x02 \x01(\x0e\x32\x13.naila.ServerHealth\x12\x0f\n\x07message\x18\x03 \x01(\t*V\n\nAudioCodec\x12\x17\n\x13\x41UDIO_CODEC_UNKNOWN\x10\x00\x12\x19\n\x15\x41UDIO_CODEC_PCM_S16LE\x10\x01\x12\x14\n\x10\x41UDIO_CODEC_OPUS\x10\x02*\x8c\x01\n\x0bSpeechEvent\x12\x18\n\x14SPEECH_EVENT_UNKNOWN\x10\x00\x12\x16\n\x12SPEECH_EVENT_START\x10\x01\x12\x19\n\x15SPEECH_EVENT_CONTINUE\x10\x02\x12\x14\n\x10SPEECH_EVENT_END\x10\x03\x12\x1a\n\x16SPEECH_EVENT_INTERRUPT\x10\x04*q\n\tErrorCode\x12\x0e\n\nERROR_NONE\x10\x00\x12\x14\n\x10\x45RROR_STT_FAILED\x10\x01\x12\x14\n\x10\x45RROR_LLM_FAILED\x10\x02\x12\x14\n\x10\x45RROR_TTS_FAILED\x10\x03\x12\x12\n\x0e\x45RROR_INTERNAL\x10\x63*}\n\x0cServerHealth\x12\x19\n\x15SERVER_HEALTH_UNKNOWN\x10\x00\x12\x19\n\x15SERVER_HEALTH_HEALTHY\x10\x01\x12\x1a\n\x16SERVER_HEALTH_DEGRADED\x10\x02\x12\x1b\n\x17SERVER_HEALTH_UNHEALTHY\x10\x03\x32\x84\x01\n\x07NailaAI\x12?\n\x12StreamConversation\x12\x11.naila.AudioInput\x1a\x12.naila.AudioOutput(\x01\x30\x01\x12\x38\n\tGetStatus\x12\x14.naila.StatusRequest\x1a\x15.naila.StatusResponseB\x02H\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,16 +32,28 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'naila_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'H\001'
-  _globals['_AUDIOCODEC']._serialized_start=548
-  _globals['_AUDIOCODEC']._serialized_end=634
-  _globals['_SPEECHEVENT']._serialized_start=637
-  _globals['_SPEECHEVENT']._serialized_end=777
-  _globals['_ERRORCODE']._serialized_start=779
-  _globals['_ERRORCODE']._serialized_end=892
+  _globals['_AUDIOCODEC']._serialized_start=1434
+  _globals['_AUDIOCODEC']._serialized_end=1520
+  _globals['_SPEECHEVENT']._serialized_start=1523
+  _globals['_SPEECHEVENT']._serialized_end=1663
+  _globals['_ERRORCODE']._serialized_start=1665
+  _globals['_ERRORCODE']._serialized_end=1778
+  _globals['_SERVERHEALTH']._serialized_start=1780
+  _globals['_SERVERHEALTH']._serialized_end=1905
   _globals['_AUDIOINPUT']._serialized_start=23
   _globals['_AUDIOINPUT']._serialized_end=309
   _globals['_AUDIOOUTPUT']._serialized_start=312
   _globals['_AUDIOOUTPUT']._serialized_end=546
-  _globals['_NAILAAI']._serialized_start=894
-  _globals['_NAILAAI']._serialized_end=968
+  _globals['_STATUSREQUEST']._serialized_start=548
+  _globals['_STATUSREQUEST']._serialized_end=616
+  _globals['_STATUSRESPONSE']._serialized_start=619
+  _globals['_STATUSRESPONSE']._serialized_end=1089
+  _globals['_MODELINFO']._serialized_start=1091
+  _globals['_MODELINFO']._serialized_end=1169
+  _globals['_SERVERMETRICS']._serialized_start=1172
+  _globals['_SERVERMETRICS']._serialized_end=1345
+  _globals['_COMPONENTHEALTH']._serialized_start=1347
+  _globals['_COMPONENTHEALTH']._serialized_end=1432
+  _globals['_NAILAAI']._serialized_start=1908
+  _globals['_NAILAAI']._serialized_end=2040
 # @@protoc_insertion_point(module_scope)

--- a/ai-server/rpc/generated/naila_pb2_grpc.py
+++ b/ai-server/rpc/generated/naila_pb2_grpc.py
@@ -43,6 +43,11 @@ class NailaAIStub(object):
                 request_serializer=naila__pb2.AudioInput.SerializeToString,
                 response_deserializer=naila__pb2.AudioOutput.FromString,
                 _registered_method=True)
+        self.GetStatus = channel.unary_unary(
+                '/naila.NailaAI/GetStatus',
+                request_serializer=naila__pb2.StatusRequest.SerializeToString,
+                response_deserializer=naila__pb2.StatusResponse.FromString,
+                _registered_method=True)
 
 
 class NailaAIServicer(object):
@@ -59,6 +64,14 @@ class NailaAIServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def GetStatus(self, request, context):
+        """Server status and capability check.
+        Call before opening streams to verify readiness and discover capabilities.
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_NailaAIServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -66,6 +79,11 @@ def add_NailaAIServicer_to_server(servicer, server):
                     servicer.StreamConversation,
                     request_deserializer=naila__pb2.AudioInput.FromString,
                     response_serializer=naila__pb2.AudioOutput.SerializeToString,
+            ),
+            'GetStatus': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetStatus,
+                    request_deserializer=naila__pb2.StatusRequest.FromString,
+                    response_serializer=naila__pb2.StatusResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -99,6 +117,33 @@ class NailaAI(object):
             '/naila.NailaAI/StreamConversation',
             naila__pb2.AudioInput.SerializeToString,
             naila__pb2.AudioOutput.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def GetStatus(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/naila.NailaAI/GetStatus',
+            naila__pb2.StatusRequest.SerializeToString,
+            naila__pb2.StatusResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/ai-server/rpc/service.py
+++ b/ai-server/rpc/service.py
@@ -16,11 +16,14 @@ from typing import Optional
 
 from typing import TYPE_CHECKING
 
+import psutil
+
 from rpc.generated import naila_pb2, naila_pb2_grpc
 from utils import get_logger
 
 if TYPE_CHECKING:
     from agents.orchestrator import NAILAOrchestrator
+    from managers.ai_model import AIModelManager
 
 
 logger = get_logger(__name__)
@@ -63,15 +66,124 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
     orchestrator which runs the LangGraph pipeline.
     """
 
+    # Services considered critical for the voice pipeline.
+    # If any of these are down, overall health is UNHEALTHY.
+    _CRITICAL_SERVICES = {"stt", "llm"}
+
     def __init__(self):
         self.stt_service = None
         self.orchestrator: Optional[NAILAOrchestrator] = None
+        self._ai_model_manager: Optional[AIModelManager] = None
+        self._start_time: Optional[float] = None
+        self._server_version: str = ""
+        self._max_concurrent_streams: int = 0
 
     def set_stt_service(self, stt_service):
         self.stt_service = stt_service
 
     def set_orchestrator(self, orchestrator):
         self.orchestrator = orchestrator
+
+    def set_ai_model_manager(self, manager: "AIModelManager"):
+        self._ai_model_manager = manager
+
+    def set_server_info(
+        self,
+        start_time: Optional[float] = None,
+        server_version: str = "",
+        max_concurrent_streams: int = 0,
+    ):
+        self._start_time = start_time
+        self._server_version = server_version
+        self._max_concurrent_streams = max_concurrent_streams
+
+    async def GetStatus(self, request, context):
+        """Return server health, capabilities, and optional model/metrics info."""
+        uptime = int(time.time() - self._start_time) if self._start_time else 0
+
+        # Build component health and determine overall health
+        components = []
+        health = naila_pb2.SERVER_HEALTH_HEALTHY
+
+        if self._ai_model_manager:
+            status = self._ai_model_manager.get_status()
+
+            if not status.get("models_loaded"):
+                health = naila_pb2.SERVER_HEALTH_UNHEALTHY
+
+            for name in ("stt", "llm", "tts", "vision"):
+                svc = status.get(name)
+                if svc is None:
+                    continue
+                ready = svc.get("ready", False)
+                svc_health = (
+                    naila_pb2.SERVER_HEALTH_HEALTHY
+                    if ready
+                    else naila_pb2.SERVER_HEALTH_UNHEALTHY
+                )
+                components.append(naila_pb2.ComponentHealth(
+                    name=name,
+                    health=svc_health,
+                    message="ready" if ready else "not ready",
+                ))
+                if not ready:
+                    if name in self._CRITICAL_SERVICES:
+                        health = naila_pb2.SERVER_HEALTH_UNHEALTHY
+                    elif health == naila_pb2.SERVER_HEALTH_HEALTHY:
+                        health = naila_pb2.SERVER_HEALTH_DEGRADED
+        else:
+            health = naila_pb2.SERVER_HEALTH_UNHEALTHY
+
+        response = naila_pb2.StatusResponse(
+            health=health,
+            server_version=self._server_version,
+            uptime_seconds=uptime,
+            supported_input_codecs=[
+                naila_pb2.AUDIO_CODEC_PCM_S16LE,
+                naila_pb2.AUDIO_CODEC_OPUS,
+            ],
+            supported_output_codecs=[
+                naila_pb2.AUDIO_CODEC_PCM_S16LE,
+            ],
+            max_concurrent_streams=self._max_concurrent_streams,
+            components=components,
+        )
+
+        # Model info (only when requested)
+        if request.include_model_info and self._ai_model_manager:
+            status = self._ai_model_manager.get_status()
+            for name, field in [
+                ("stt", "stt_model"),
+                ("llm", "llm_model"),
+                ("tts", "tts_model"),
+                ("vision", "vision_model"),
+            ]:
+                svc = status.get(name)
+                if svc is None:
+                    continue
+                model_path = svc.get("model_path", "")
+                hw = svc.get("hardware") or {}
+                getattr(response, field).CopyFrom(naila_pb2.ModelInfo(
+                    model_id=model_path.rsplit("/", 1)[-1] if model_path else "",
+                    loaded=svc.get("ready", False),
+                    device=hw.get("device_type", ""),
+                ))
+
+        # Metrics (only when requested)
+        if request.include_metrics:
+            cpu = 0.0
+            mem = 0.0
+            try:
+                cpu = psutil.cpu_percent() / 100.0
+                mem = psutil.virtual_memory().percent / 100.0
+            except Exception:
+                logger.debug("metrics_collection_failed")
+            response.metrics.CopyFrom(naila_pb2.ServerMetrics(
+                cpu_utilization=cpu,
+                memory_utilization=mem,
+            ))
+
+        return response
 
     async def StreamConversation(self, request_iterator, context):
         """Bidirectional streaming voice conversation.

--- a/ai-server/rpc/service.py
+++ b/ai-server/rpc/service.py
@@ -104,6 +104,7 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
         # Build component health and determine overall health
         components = []
         health = naila_pb2.SERVER_HEALTH_HEALTHY
+        status = None
 
         if self._ai_model_manager:
             status = self._ai_model_manager.get_status()
@@ -149,9 +150,8 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
             components=components,
         )
 
-        # Model info (only when requested)
-        if request.include_model_info and self._ai_model_manager:
-            status = self._ai_model_manager.get_status()
+        # Model info (only when requested — reuse `status` from above)
+        if request.include_model_info and status:
             for name, field in [
                 ("stt", "stt_model"),
                 ("llm", "llm_model"),
@@ -174,7 +174,7 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
             cpu = 0.0
             mem = 0.0
             try:
-                cpu = psutil.cpu_percent() / 100.0
+                cpu = psutil.cpu_percent(interval=0.0) / 100.0
                 mem = psutil.virtual_memory().percent / 100.0
             except Exception:
                 logger.debug("metrics_collection_failed")

--- a/ai-server/server/lifecycle.py
+++ b/ai-server/server/lifecycle.py
@@ -94,9 +94,20 @@ class ServerLifecycleManager:
                 if self.orchestrator:
                     self.orchestrator.set_vision_service(vision_service)
 
-            # Wire shared orchestrator into gRPC servicer
+            # Wire shared orchestrator and status info into gRPC servicer
             if self.grpc_servicer and self.orchestrator:
                 self.grpc_servicer.set_orchestrator(self.orchestrator)
+
+            if self.grpc_servicer:
+                self.grpc_servicer.set_ai_model_manager(self.ai_model_manager)
+                self.grpc_servicer.set_server_info(
+                    start_time=self._start_time.timestamp() if self._start_time else None,
+                    server_version="1.0.0",
+                    max_concurrent_streams=(
+                        self.grpc_server.config.max_concurrent_streams
+                        if self.grpc_server else 0
+                    ),
+                )
 
             # Stage: Register protocol handlers
             logger.info("startup_stage", stage=StartupStage.REGISTER_HANDLERS.value)

--- a/ai-server/server/lifecycle.py
+++ b/ai-server/server/lifecycle.py
@@ -3,11 +3,29 @@ import contextlib
 import os
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
 from typing import Optional
 from .health_monitor import HealthMonitor
 from utils.platform import get_platform_info
 from managers.ai_model import AIModelManager
 from utils import get_logger
+
+
+def _read_server_version() -> str:
+    """Read version from pyproject.toml (single source of truth)."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+    try:
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        data = tomllib.loads(pyproject.read_text())
+        return data["project"]["version"]
+    except Exception:
+        return "unknown"
+
+
+SERVER_VERSION = _read_server_version()
 
 
 logger = get_logger(__name__)
@@ -102,7 +120,7 @@ class ServerLifecycleManager:
                 self.grpc_servicer.set_ai_model_manager(self.ai_model_manager)
                 self.grpc_servicer.set_server_info(
                     start_time=self._start_time.timestamp() if self._start_time else None,
-                    server_version="1.0.0",
+                    server_version=SERVER_VERSION,
                     max_concurrent_streams=(
                         self.grpc_server.config.max_concurrent_streams
                         if self.grpc_server else 0
@@ -208,7 +226,7 @@ class ServerLifecycleManager:
         startup_data = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "event": "server_startup",
-            "server_version": "1.0.0",
+            "server_version": SERVER_VERSION,
             "config": {
                 "mqtt_broker": f"{self.mqtt_service.config.broker_host}:{self.mqtt_service.config.broker_port}",
                 "mqtt_qos": self.mqtt_service.config.qos,

--- a/ai-server/tests/unit/test_grpc_service.py
+++ b/ai-server/tests/unit/test_grpc_service.py
@@ -1,6 +1,7 @@
-"""Unit tests for the gRPC NailaAI service — StreamConversation and helpers."""
+"""Unit tests for the gRPC NailaAI service — StreamConversation, GetStatus, and helpers."""
 
 import asyncio
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -348,3 +349,295 @@ class TestExtractAudio:
         msg = MagicMock()
         msg.WhichOneof.return_value = None
         assert NailaAIServicer._extract_audio(msg) is None
+
+
+# ── GetStatus helpers ───────────────────────────────────────────────────────
+
+def _make_ai_model_manager(
+    models_loaded=True,
+    llm_ready=True,
+    stt_ready=True,
+    tts_ready=True,
+    vision_ready=True,
+):
+    """Build a mock AIModelManager with configurable service readiness."""
+    manager = MagicMock()
+
+    def _svc_status(name, ready, model_path, **extras):
+        status = {
+            "ready": ready,
+            "model_path": f"/models/{model_path}",
+            "model_exists": ready,
+            "hardware": {"device_type": "cuda", "device_name": "NVIDIA RTX 4090"},
+        }
+        status.update(extras)
+        return status
+
+    manager.get_status.return_value = {
+        "models_loaded": models_loaded,
+        "llm": _svc_status("llm", llm_ready, "llama-3-8b.gguf", context_size=8192, max_tokens=512),
+        "stt": _svc_status("stt", stt_ready, "whisper-small-en", sample_rate=16000),
+        "tts": _svc_status("tts", tts_ready, "lessac.onnx", sample_rate=22050, voice="lessac"),
+        "vision": _svc_status("vision", vision_ready, "yolov8n.pt", model_name="yolov8n"),
+    }
+    return manager
+
+
+def _make_status_servicer(
+    models_loaded=True,
+    llm_ready=True,
+    stt_ready=True,
+    tts_ready=True,
+    vision_ready=True,
+    start_time=None,
+    max_concurrent_streams=4,
+):
+    """Return a NailaAIServicer configured for GetStatus tests."""
+    servicer = NailaAIServicer()
+    servicer.set_ai_model_manager(
+        _make_ai_model_manager(models_loaded, llm_ready, stt_ready, tts_ready, vision_ready)
+    )
+    servicer.set_server_info(
+        start_time=start_time or time.time(),
+        server_version="1.0.0",
+        max_concurrent_streams=max_concurrent_streams,
+    )
+    return servicer
+
+
+# ── GetStatus — happy path ──────────────────────────────────────────────────
+
+class TestGetStatus:
+    @pytest.mark.asyncio
+    async def test_healthy_response(self):
+        """All services ready should return HEALTHY."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.health == naila_pb2.SERVER_HEALTH_HEALTHY
+        assert response.server_version == "1.0.0"
+        assert response.uptime_seconds >= 0
+
+    @pytest.mark.asyncio
+    async def test_supported_codecs(self):
+        """Response should advertise PCM and Opus input, PCM output."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert naila_pb2.AUDIO_CODEC_PCM_S16LE in response.supported_input_codecs
+        assert naila_pb2.AUDIO_CODEC_PCM_S16LE in response.supported_output_codecs
+
+    @pytest.mark.asyncio
+    async def test_max_concurrent_streams(self):
+        """Response should reflect the configured max concurrent streams."""
+        servicer = _make_status_servicer(max_concurrent_streams=8)
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.max_concurrent_streams == 8
+
+    @pytest.mark.asyncio
+    async def test_uptime_calculation(self):
+        """Uptime should reflect time since server start."""
+        start = time.time() - 120  # started 2 minutes ago
+        servicer = _make_status_servicer(start_time=start)
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.uptime_seconds >= 119  # allow 1s tolerance
+
+    @pytest.mark.asyncio
+    async def test_component_health_all_ready(self):
+        """When all services are ready, all components should be HEALTHY."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        component_names = [c.name for c in response.components]
+        assert "stt" in component_names
+        assert "llm" in component_names
+        assert "tts" in component_names
+        assert "vision" in component_names
+
+        for component in response.components:
+            assert component.health == naila_pb2.SERVER_HEALTH_HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_component_health_partial_failure(self):
+        """When a service is not ready, its component should be UNHEALTHY."""
+        servicer = _make_status_servicer(tts_ready=False)
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        tts_component = next(c for c in response.components if c.name == "tts")
+        assert tts_component.health == naila_pb2.SERVER_HEALTH_UNHEALTHY
+
+        llm_component = next(c for c in response.components if c.name == "llm")
+        assert llm_component.health == naila_pb2.SERVER_HEALTH_HEALTHY
+
+
+# ── GetStatus — degraded / unhealthy ────────────────────────────────────────
+
+class TestGetStatusHealth:
+    @pytest.mark.asyncio
+    async def test_degraded_when_non_critical_service_down(self):
+        """When vision is down but core services are up, health should be DEGRADED."""
+        servicer = _make_status_servicer(vision_ready=False)
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.health == naila_pb2.SERVER_HEALTH_DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_degraded_when_tts_down(self):
+        """When TTS is down, health should be DEGRADED (voice still works inbound)."""
+        servicer = _make_status_servicer(tts_ready=False)
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.health == naila_pb2.SERVER_HEALTH_DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_when_llm_down(self):
+        """When LLM is down, health should be UNHEALTHY (can't generate responses)."""
+        servicer = _make_status_servicer(llm_ready=False)
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.health == naila_pb2.SERVER_HEALTH_UNHEALTHY
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_when_stt_down(self):
+        """When STT is down, health should be UNHEALTHY (can't process voice input)."""
+        servicer = _make_status_servicer(stt_ready=False)
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.health == naila_pb2.SERVER_HEALTH_UNHEALTHY
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_when_models_not_loaded(self):
+        """When models_loaded is False, overall health should be UNHEALTHY."""
+        servicer = _make_status_servicer(models_loaded=False)
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.health == naila_pb2.SERVER_HEALTH_UNHEALTHY
+
+
+# ── GetStatus — model info ──────────────────────────────────────────────────
+
+class TestGetStatusModelInfo:
+    @pytest.mark.asyncio
+    async def test_model_info_included_when_requested(self):
+        """Model info should be populated when include_model_info=True."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest(include_model_info=True)
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.llm_model.loaded is True
+        assert response.llm_model.model_id != ""
+        assert response.stt_model.loaded is True
+        assert response.tts_model.loaded is True
+        assert response.vision_model.loaded is True
+
+    @pytest.mark.asyncio
+    async def test_model_info_has_device(self):
+        """Model info should include the hardware device."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest(include_model_info=True)
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.llm_model.device != ""
+
+    @pytest.mark.asyncio
+    async def test_model_info_not_included_when_not_requested(self):
+        """Model info should be empty when include_model_info=False."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest(include_model_info=False)
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        # Protobuf default: unset sub-messages have all-default fields
+        assert response.llm_model.model_id == ""
+        assert response.stt_model.model_id == ""
+
+    @pytest.mark.asyncio
+    async def test_model_info_partial_services(self):
+        """Model info for unavailable services should show loaded=False."""
+        servicer = _make_status_servicer(tts_ready=False)
+        request = naila_pb2.StatusRequest(include_model_info=True)
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.tts_model.loaded is False
+        assert response.llm_model.loaded is True
+
+
+# ── GetStatus — metrics ─────────────────────────────────────────────────────
+
+class TestGetStatusMetrics:
+    @pytest.mark.asyncio
+    async def test_metrics_included_when_requested(self):
+        """Server metrics should be populated when include_metrics=True."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest(include_metrics=True)
+
+        with patch("rpc.service.psutil") as mock_psutil:
+            mock_psutil.cpu_percent.return_value = 45.0
+            mock_psutil.virtual_memory.return_value = SimpleNamespace(percent=62.5)
+            response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.metrics.cpu_utilization == pytest.approx(0.45, abs=0.01)
+        assert response.metrics.memory_utilization == pytest.approx(0.625, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_metrics_not_included_when_not_requested(self):
+        """Metrics should be empty when include_metrics=False."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest(include_metrics=False)
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.metrics.cpu_utilization == 0.0
+
+    @pytest.mark.asyncio
+    async def test_metrics_handles_psutil_failure(self):
+        """Metrics should gracefully handle psutil errors."""
+        servicer = _make_status_servicer()
+        request = naila_pb2.StatusRequest(include_metrics=True)
+
+        with patch("rpc.service.psutil") as mock_psutil:
+            mock_psutil.cpu_percent.side_effect = RuntimeError("no access")
+            mock_psutil.virtual_memory.side_effect = RuntimeError("no access")
+            response = await servicer.GetStatus(request, _grpc_context())
+
+        # Should still return a valid response with zeroed metrics
+        assert response.health != naila_pb2.SERVER_HEALTH_UNKNOWN
+        assert response.metrics.cpu_utilization == 0.0
+
+
+# ── GetStatus — no manager configured ───────────────────────────────────────
+
+class TestGetStatusNoManager:
+    @pytest.mark.asyncio
+    async def test_no_manager_returns_unhealthy(self):
+        """When AIModelManager is not set, server should report UNHEALTHY."""
+        servicer = NailaAIServicer()
+        servicer.set_server_info(start_time=time.time(), server_version="1.0.0")
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.health == naila_pb2.SERVER_HEALTH_UNHEALTHY
+        assert response.server_version == "1.0.0"
+        assert len(response.components) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_server_info_uses_defaults(self):
+        """When server info is not set, defaults should be used."""
+        servicer = NailaAIServicer()
+        servicer.set_ai_model_manager(_make_ai_model_manager())
+        request = naila_pb2.StatusRequest()
+        response = await servicer.GetStatus(request, _grpc_context())
+
+        assert response.server_version == ""
+        assert response.uptime_seconds == 0

--- a/hub/build.rs
+++ b/hub/build.rs
@@ -1,6 +1,6 @@
 use tonic_prost_build;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_prost_build::compile_protos("../shared/naila.proto")?;
+    tonic_prost_build::compile_protos("../proto/naila.proto")?;
     Ok(())
 }

--- a/hub/src/grpc.rs
+++ b/hub/src/grpc.rs
@@ -19,7 +19,7 @@ pub mod proto {
 }
 
 use proto::naila_ai_client::NailaAiClient;
-use proto::{AudioCodec, AudioInput, AudioOutput, SpeechEvent};
+use proto::{AudioCodec, AudioInput, AudioOutput, SpeechEvent, StatusRequest};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Config
@@ -89,11 +89,13 @@ pub async fn run_grpc_client(
                 Ok(()) => {
                     // Graceful shutdown (audio bus closed or cancellation).
                     metrics.grpc_connected.store(false, Ordering::Relaxed);
+                    metrics.clear_ai_status();
                     info!("gRPC stream ended cleanly");
                     return;
                 }
                 Err(e) => {
                     metrics.grpc_connected.store(false, Ordering::Relaxed);
+                    metrics.clear_ai_status();
                     metrics.grpc_reconnects.fetch_add(1, Ordering::Relaxed);
                     error!("gRPC error: {e}");
                     drain_stale(&mut audio_rx);
@@ -144,7 +146,33 @@ async fn connect_and_stream(
 
     let mut client = NailaAiClient::new(channel);
 
-    info!("gRPC channel connected, opening stream");
+    info!("gRPC channel connected, checking AI server status");
+
+    // Call GetStatus before opening the streaming RPC. This lets us
+    // verify the server is healthy and cache its status for /health.
+    match client.get_status(StatusRequest {
+        include_model_info: true,
+        include_metrics: true,
+    }).await {
+        Ok(response) => {
+            let status = response.into_inner();
+            let health = proto::ServerHealth::try_from(status.health)
+                .unwrap_or(proto::ServerHealth::Unknown);
+            info!(
+                health = ?health,
+                version = %status.server_version,
+                uptime_secs = status.uptime_seconds,
+                "AI server status received"
+            );
+            metrics.update_ai_status(status);
+        }
+        Err(e) => {
+            warn!("GetStatus failed (server may not support it yet): {e}");
+            metrics.clear_ai_status();
+        }
+    }
+
+    info!("opening bidirectional stream");
 
     // Tonic takes ownership of the request stream at call time, so we
     // can't hand audio_rx directly — it needs to survive reconnects.

--- a/hub/src/metrics.rs
+++ b/hub/src/metrics.rs
@@ -1,7 +1,10 @@
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
 use std::time::Instant;
 
 use serde::Serialize;
+
+use crate::grpc::proto;
 
 /// Shared counters and gauges for the hub. Created once in `main()`,
 /// passed as `Arc<HubMetrics>` to subsystems that bump the values.
@@ -21,6 +24,47 @@ pub struct HubMetrics {
     pub grpc_connected: AtomicBool,
     /// Process start time (for uptime calculation).
     pub start_time: Instant,
+    /// Cached AI server status from the last successful GetStatus call.
+    ai_status: Mutex<Option<AiServerStatus>>,
+}
+
+/// Cached snapshot of the AI server's GetStatus response, converted to
+/// serializable types so we don't hold proto types across the Mutex boundary.
+#[derive(Clone, Serialize)]
+pub struct AiServerStatus {
+    pub health: String,
+    pub server_version: String,
+    pub uptime_seconds: u64,
+    pub max_concurrent_streams: u32,
+    pub components: Vec<AiComponentHealth>,
+    pub models: Vec<AiModelInfo>,
+    pub cpu_utilization: f32,
+    pub memory_utilization: f32,
+}
+
+#[derive(Clone, Serialize)]
+pub struct AiComponentHealth {
+    pub name: String,
+    pub health: String,
+    pub message: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct AiModelInfo {
+    pub name: String,
+    pub model_id: String,
+    pub loaded: bool,
+    pub device: String,
+}
+
+fn health_str(value: i32) -> String {
+    match proto::ServerHealth::try_from(value) {
+        Ok(proto::ServerHealth::Healthy) => "healthy",
+        Ok(proto::ServerHealth::Degraded) => "degraded",
+        Ok(proto::ServerHealth::Unhealthy) => "unhealthy",
+        _ => "unknown",
+    }
+    .to_owned()
 }
 
 impl HubMetrics {
@@ -33,11 +77,70 @@ impl HubMetrics {
             grpc_reconnects: AtomicU64::new(0),
             grpc_connected: AtomicBool::new(false),
             start_time: Instant::now(),
+            ai_status: Mutex::new(None),
         }
+    }
+
+    /// Cache the AI server's status response.
+    pub fn update_ai_status(&self, status: proto::StatusResponse) {
+        let components = status
+            .components
+            .iter()
+            .map(|c| AiComponentHealth {
+                name: c.name.clone(),
+                health: health_str(c.health),
+                message: c.message.clone(),
+            })
+            .collect();
+
+        let models = [
+            ("stt", &status.stt_model),
+            ("llm", &status.llm_model),
+            ("tts", &status.tts_model),
+            ("vision", &status.vision_model),
+        ]
+        .into_iter()
+        .filter_map(|(name, maybe_model)| {
+            let m = maybe_model.as_ref()?;
+            if m.model_id.is_empty() && !m.loaded {
+                return None;
+            }
+            Some(AiModelInfo {
+                name: name.to_owned(),
+                model_id: m.model_id.clone(),
+                loaded: m.loaded,
+                device: m.device.clone(),
+            })
+        })
+        .collect();
+
+        let (cpu, mem) = status
+            .metrics
+            .as_ref()
+            .map(|m| (m.cpu_utilization, m.memory_utilization))
+            .unwrap_or((0.0, 0.0));
+
+        *self.ai_status.lock().unwrap() = Some(AiServerStatus {
+            health: health_str(status.health),
+            server_version: status.server_version,
+            uptime_seconds: status.uptime_seconds,
+            max_concurrent_streams: status.max_concurrent_streams,
+            components,
+            models,
+            cpu_utilization: cpu,
+            memory_utilization: mem,
+        });
+    }
+
+    /// Clear cached AI status (e.g., on disconnect).
+    pub fn clear_ai_status(&self) {
+        *self.ai_status.lock().unwrap() = None;
     }
 
     /// Snapshot the current state into a serializable response.
     pub fn snapshot(&self, active_devices: usize) -> HealthResponse {
+        let ai_server = self.ai_status.lock().unwrap().clone();
+
         HealthResponse {
             status: "ok",
             uptime_secs: self.start_time.elapsed().as_secs(),
@@ -48,6 +151,7 @@ impl HubMetrics {
             vad_ends: self.vad_ends.load(Ordering::Relaxed),
             tts_frames_routed: self.tts_frames_routed.load(Ordering::Relaxed),
             grpc_reconnects: self.grpc_reconnects.load(Ordering::Relaxed),
+            ai_server,
         }
     }
 }
@@ -63,4 +167,8 @@ pub struct HealthResponse {
     pub vad_ends: u64,
     pub tts_frames_routed: u64,
     pub grpc_reconnects: u64,
+    /// AI server status from the last successful GetStatus call.
+    /// `None` if the server hasn't been reached or doesn't support GetStatus.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ai_server: Option<AiServerStatus>,
 }

--- a/hub/src/metrics.rs
+++ b/hub/src/metrics.rs
@@ -172,3 +172,188 @@ pub struct HealthResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ai_server: Option<AiServerStatus>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grpc::proto;
+
+    /// Fully populated healthy StatusResponse for test reuse.
+    fn healthy_status() -> proto::StatusResponse {
+        proto::StatusResponse {
+            health: proto::ServerHealth::Healthy as i32,
+            server_version: "test-1.0.0".to_owned(),
+            uptime_seconds: 42,
+            max_concurrent_streams: 4,
+            components: vec![
+                proto::ComponentHealth {
+                    name: "stt".to_owned(),
+                    health: proto::ServerHealth::Healthy as i32,
+                    message: "ready".to_owned(),
+                },
+                proto::ComponentHealth {
+                    name: "llm".to_owned(),
+                    health: proto::ServerHealth::Healthy as i32,
+                    message: "ready".to_owned(),
+                },
+            ],
+            stt_model: Some(proto::ModelInfo {
+                model_id: "whisper-small.en".to_owned(),
+                version: "1.0".to_owned(),
+                loaded: true,
+                device: "cuda:0".to_owned(),
+            }),
+            llm_model: Some(proto::ModelInfo {
+                model_id: "llama-3-8b".to_owned(),
+                version: "1.0".to_owned(),
+                loaded: true,
+                device: "cuda:0".to_owned(),
+            }),
+            tts_model: None,
+            vision_model: None,
+            metrics: Some(proto::ServerMetrics {
+                cpu_utilization: 0.45,
+                memory_utilization: 0.72,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn update_caches_health_version_uptime() {
+        let m = HubMetrics::new();
+        m.update_ai_status(healthy_status());
+
+        let ai = m.snapshot(0).ai_server.unwrap();
+        assert_eq!(ai.health, "healthy");
+        assert_eq!(ai.server_version, "test-1.0.0");
+        assert_eq!(ai.uptime_seconds, 42);
+        assert_eq!(ai.max_concurrent_streams, 4);
+    }
+
+    #[test]
+    fn update_maps_components() {
+        let m = HubMetrics::new();
+        m.update_ai_status(healthy_status());
+
+        let ai = m.snapshot(0).ai_server.unwrap();
+        assert_eq!(ai.components.len(), 2);
+        assert_eq!(ai.components[0].name, "stt");
+        assert_eq!(ai.components[0].health, "healthy");
+        assert_eq!(ai.components[0].message, "ready");
+        assert_eq!(ai.components[1].name, "llm");
+    }
+
+    #[test]
+    fn update_maps_loaded_models_and_filters_absent() {
+        let m = HubMetrics::new();
+        m.update_ai_status(healthy_status());
+
+        let ai = m.snapshot(0).ai_server.unwrap();
+        // stt and llm have models; tts and vision are None → filtered out
+        assert_eq!(ai.models.len(), 2);
+        assert_eq!(ai.models[0].name, "stt");
+        assert_eq!(ai.models[0].model_id, "whisper-small.en");
+        assert!(ai.models[0].loaded);
+        assert_eq!(ai.models[0].device, "cuda:0");
+        assert_eq!(ai.models[1].name, "llm");
+        assert_eq!(ai.models[1].model_id, "llama-3-8b");
+    }
+
+    #[test]
+    fn update_filters_empty_unloaded_models() {
+        let m = HubMetrics::new();
+        let mut status = healthy_status();
+        // Empty model_id + not loaded → should be filtered out
+        status.tts_model = Some(proto::ModelInfo {
+            model_id: String::new(),
+            loaded: false,
+            ..Default::default()
+        });
+        m.update_ai_status(status);
+
+        let ai = m.snapshot(0).ai_server.unwrap();
+        assert_eq!(ai.models.len(), 2); // stt + llm only
+    }
+
+    #[test]
+    fn update_extracts_metrics() {
+        let m = HubMetrics::new();
+        m.update_ai_status(healthy_status());
+
+        let ai = m.snapshot(0).ai_server.unwrap();
+        assert!((ai.cpu_utilization - 0.45).abs() < 0.001);
+        assert!((ai.memory_utilization - 0.72).abs() < 0.001);
+    }
+
+    #[test]
+    fn update_defaults_metrics_when_absent() {
+        let m = HubMetrics::new();
+        let mut status = healthy_status();
+        status.metrics = None;
+        m.update_ai_status(status);
+
+        let ai = m.snapshot(0).ai_server.unwrap();
+        assert_eq!(ai.cpu_utilization, 0.0);
+        assert_eq!(ai.memory_utilization, 0.0);
+    }
+
+    #[test]
+    fn update_maps_degraded_health() {
+        let m = HubMetrics::new();
+        let mut status = healthy_status();
+        status.health = proto::ServerHealth::Degraded as i32;
+        m.update_ai_status(status);
+
+        assert_eq!(m.snapshot(0).ai_server.unwrap().health, "degraded");
+    }
+
+    #[test]
+    fn update_maps_unknown_for_invalid_health_value() {
+        let m = HubMetrics::new();
+        let mut status = healthy_status();
+        status.health = 99; // not a valid ServerHealth variant
+        m.update_ai_status(status);
+
+        assert_eq!(m.snapshot(0).ai_server.unwrap().health, "unknown");
+    }
+
+    #[test]
+    fn clear_removes_cached_status() {
+        let m = HubMetrics::new();
+        m.update_ai_status(healthy_status());
+        assert!(m.snapshot(0).ai_server.is_some());
+
+        m.clear_ai_status();
+        assert!(m.snapshot(0).ai_server.is_none());
+    }
+
+    #[test]
+    fn snapshot_without_status_has_none() {
+        let m = HubMetrics::new();
+        let snap = m.snapshot(0);
+        assert!(snap.ai_server.is_none());
+        assert_eq!(snap.status, "ok");
+    }
+
+    #[test]
+    fn snapshot_reflects_counters_and_devices() {
+        let m = HubMetrics::new();
+        m.frames_forwarded.store(100, Ordering::Relaxed);
+        m.vad_onsets.store(5, Ordering::Relaxed);
+        m.vad_ends.store(4, Ordering::Relaxed);
+        m.tts_frames_routed.store(50, Ordering::Relaxed);
+        m.grpc_reconnects.store(2, Ordering::Relaxed);
+        m.grpc_connected.store(true, Ordering::Relaxed);
+
+        let snap = m.snapshot(3);
+        assert_eq!(snap.active_devices, 3);
+        assert_eq!(snap.frames_forwarded, 100);
+        assert_eq!(snap.vad_onsets, 5);
+        assert_eq!(snap.vad_ends, 4);
+        assert_eq!(snap.tts_frames_routed, 50);
+        assert_eq!(snap.grpc_reconnects, 2);
+        assert!(snap.grpc_connected);
+    }
+}

--- a/hub/tests/loopback.rs
+++ b/hub/tests/loopback.rs
@@ -13,7 +13,7 @@ use hub::audio::AudioBus;
 use hub::device::run_device;
 use hub::grpc::proto::audio_input::Audio;
 use hub::grpc::proto::naila_ai_server::{NailaAi, NailaAiServer};
-use hub::grpc::proto::{AudioInput, AudioOutput};
+use hub::grpc::proto::{AudioInput, AudioOutput, StatusRequest, StatusResponse};
 use hub::grpc::{run_grpc_client, GrpcConfig};
 use hub::metrics::HubMetrics;
 use hub::vad::VadConfig;
@@ -60,6 +60,19 @@ impl NailaAi for EchoAiService {
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+    }
+
+    async fn get_status(
+        &self,
+        _request: Request<StatusRequest>,
+    ) -> Result<Response<StatusResponse>, Status> {
+        Ok(Response::new(StatusResponse {
+            health: hub::grpc::proto::ServerHealth::Healthy as i32,
+            server_version: "test-1.0.0".to_owned(),
+            uptime_seconds: 42,
+            max_concurrent_streams: 4,
+            ..Default::default()
+        }))
     }
 }
 

--- a/hub/tests/loopback.rs
+++ b/hub/tests/loopback.rs
@@ -23,7 +23,24 @@ use webrtc_vad::VadMode;
 // ── Mock AI server ───────────────────────────────────────────────────────────
 
 /// Echoes every AudioInput back as an AudioOutput with the same PCM data.
-struct EchoAiService;
+/// Accepts an optional CancellationToken to close streams on demand (for
+/// disconnect testing). When the token fires, the stream handler drops
+/// its sender, which the client sees as "server closed the stream".
+struct EchoAiService {
+    stream_kill: CancellationToken,
+}
+
+impl EchoAiService {
+    fn new() -> Self {
+        Self {
+            stream_kill: CancellationToken::new(),
+        }
+    }
+
+    fn with_kill_switch(kill: CancellationToken) -> Self {
+        Self { stream_kill: kill }
+    }
+}
 
 #[tonic::async_trait]
 impl NailaAi for EchoAiService {
@@ -36,27 +53,39 @@ impl NailaAi for EchoAiService {
     ) -> Result<Response<Self::StreamConversationStream>, Status> {
         let mut inbound = request.into_inner();
         let (tx, rx) = mpsc::channel::<Result<AudioOutput, Status>>(128);
+        let kill = self.stream_kill.clone();
 
         tokio::spawn(async move {
-            while let Ok(Some(input)) = inbound.message().await {
-                let pcm = match input.audio {
-                    Some(Audio::AudioPcm(data)) => data,
-                    _ => continue,
-                };
+            loop {
+                tokio::select! {
+                    msg = inbound.message() => {
+                        let input = match msg {
+                            Ok(Some(input)) => input,
+                            _ => break,
+                        };
 
-                let output = AudioOutput {
-                    device_id: input.device_id,
-                    conversation_id: input.conversation_id,
-                    audio_pcm: pcm,
-                    sample_rate: input.sample_rate,
-                    is_final: false,
-                    ..Default::default()
-                };
+                        let pcm = match input.audio {
+                            Some(Audio::AudioPcm(data)) => data,
+                            _ => continue,
+                        };
 
-                if tx.send(Ok(output)).await.is_err() {
-                    break;
+                        let output = AudioOutput {
+                            device_id: input.device_id,
+                            conversation_id: input.conversation_id,
+                            audio_pcm: pcm,
+                            sample_rate: input.sample_rate,
+                            is_final: false,
+                            ..Default::default()
+                        };
+
+                        if tx.send(Ok(output)).await.is_err() {
+                            break;
+                        }
+                    }
+                    _ = kill.cancelled() => break,
                 }
             }
+            // Dropping tx closes the response stream.
         });
 
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
@@ -92,7 +121,7 @@ async fn audio_loopback_through_grpc() {
 
     let server_handle = tokio::spawn(async move {
         tonic::transport::Server::builder()
-            .add_service(NailaAiServer::new(EchoAiService))
+            .add_service(NailaAiServer::new(EchoAiService::new()))
             .serve_with_incoming(incoming)
             .await
             .unwrap();
@@ -166,4 +195,138 @@ async fn audio_loopback_through_grpc() {
     device_cancel.cancel();
     let _ = tokio::join!(grpc_handle, device_handle);
     server_handle.abort();
+}
+
+// ── GetStatus integration tests ─────────────────────────────────────────────
+
+/// After a successful gRPC connection, the hub should call GetStatus and
+/// cache the AI server's health, version, uptime, and capabilities.
+#[tokio::test]
+async fn grpc_connection_populates_ai_server_status() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+    let server_handle = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(NailaAiServer::new(EchoAiService::new()))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    let (audio_tx, audio_rx) = mpsc::channel(256);
+    let bus = Arc::new(AudioBus {
+        audio_tx,
+        tts_sub: DashMap::new(),
+    });
+
+    let cancel = CancellationToken::new();
+    let metrics = Arc::new(HubMetrics::new());
+    let grpc_config = GrpcConfig {
+        server_addr: format!("http://{server_addr}"),
+        initial_backoff: Duration::from_millis(50),
+        max_backoff: Duration::from_millis(200),
+    };
+
+    let grpc_handle = tokio::spawn(run_grpc_client(
+        grpc_config,
+        Arc::clone(&bus),
+        audio_rx,
+        cancel.clone(),
+        Arc::clone(&metrics),
+    ));
+
+    // Wait for connection + GetStatus call.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let snap = metrics.snapshot(0);
+    assert!(snap.grpc_connected, "should be connected");
+
+    let ai = snap
+        .ai_server
+        .expect("ai_server should be populated after connection");
+    assert_eq!(ai.health, "healthy");
+    assert_eq!(ai.server_version, "test-1.0.0");
+    assert_eq!(ai.uptime_seconds, 42);
+    assert_eq!(ai.max_concurrent_streams, 4);
+
+    cancel.cancel();
+    let _ = grpc_handle.await;
+    server_handle.abort();
+}
+
+/// When the AI server's stream closes, the hub should clear the cached
+/// status and mark the connection as down.
+#[tokio::test]
+async fn grpc_disconnect_clears_ai_server_status() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+    // Use the kill switch so we can close the stream on demand.
+    let stream_kill = CancellationToken::new();
+    let service = EchoAiService::with_kill_switch(stream_kill.clone());
+
+    let server_handle = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(NailaAiServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    let (audio_tx, audio_rx) = mpsc::channel(256);
+    let bus = Arc::new(AudioBus {
+        audio_tx,
+        tts_sub: DashMap::new(),
+    });
+
+    let cancel = CancellationToken::new();
+    let metrics = Arc::new(HubMetrics::new());
+    let grpc_config = GrpcConfig {
+        server_addr: format!("http://{server_addr}"),
+        initial_backoff: Duration::from_millis(50),
+        max_backoff: Duration::from_millis(200),
+    };
+
+    let grpc_handle = tokio::spawn(run_grpc_client(
+        grpc_config,
+        Arc::clone(&bus),
+        audio_rx,
+        cancel.clone(),
+        Arc::clone(&metrics),
+    ));
+
+    // Wait for connection.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(
+        metrics.snapshot(0).ai_server.is_some(),
+        "ai_server should be populated before disconnect"
+    );
+
+    // Close the stream and shut down the server so reconnection also fails.
+    stream_kill.cancel();
+    server_handle.abort();
+
+    // Poll until the client detects the failure and clears status.
+    let mut cleared = false;
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if metrics.snapshot(0).ai_server.is_none() {
+            cleared = true;
+            break;
+        }
+    }
+
+    assert!(cleared, "ai_server should be cleared after disconnect");
+    assert!(!metrics.snapshot(0).grpc_connected);
+    assert!(metrics.snapshot(0).grpc_reconnects >= 1);
+
+    cancel.cancel();
+    let _ = grpc_handle.await;
 }

--- a/proto/naila.proto
+++ b/proto/naila.proto
@@ -16,6 +16,10 @@ option optimize_for = SPEED;
 service NailaAI {
   // Bidirectional streaming for voice conversations
   rpc StreamConversation(stream AudioInput) returns (stream AudioOutput);
+
+  // Server status and capability check.
+  // Call before opening streams to verify readiness and discover capabilities.
+  rpc GetStatus(StatusRequest) returns (StatusResponse);
 }
 
 // =============================================================================
@@ -82,4 +86,77 @@ enum ErrorCode {
   ERROR_LLM_FAILED = 2;
   ERROR_TTS_FAILED = 3;
   ERROR_INTERNAL = 99;
+}
+
+// =============================================================================
+// Status & Health
+// =============================================================================
+
+message StatusRequest {
+  // Include model details in response (may be slower)
+  bool include_model_info = 1;
+
+  // Include resource utilization metrics
+  bool include_metrics = 2;
+}
+
+message StatusResponse {
+  // Overall server health
+  ServerHealth health = 1;
+
+  // Server version
+  string server_version = 2;
+
+  // Server uptime in seconds
+  uint64 uptime_seconds = 3;
+
+  // Audio codecs the server can process (input)
+  repeated AudioCodec supported_input_codecs = 4;
+
+  // Audio codecs the server can produce (output)
+  repeated AudioCodec supported_output_codecs = 5;
+
+  // Maximum concurrent streams the server can handle
+  uint32 max_concurrent_streams = 6;
+
+  // Active AI models (if requested)
+  ModelInfo stt_model = 7;
+  ModelInfo llm_model = 8;
+  ModelInfo tts_model = 9;
+  ModelInfo vision_model = 10;
+
+  // Current resource utilization (if requested)
+  ServerMetrics metrics = 11;
+
+  // Individual component status
+  repeated ComponentHealth components = 12;
+}
+
+enum ServerHealth {
+  SERVER_HEALTH_UNKNOWN = 0;
+  SERVER_HEALTH_HEALTHY = 1;
+  SERVER_HEALTH_DEGRADED = 2;
+  SERVER_HEALTH_UNHEALTHY = 3;
+}
+
+message ModelInfo {
+  string model_id = 1;
+  string version = 2;
+  bool loaded = 3;
+  string device = 4;
+}
+
+message ServerMetrics {
+  uint32 active_streams = 1;
+  float cpu_utilization = 2;
+  float memory_utilization = 3;
+  float gpu_utilization = 4;
+  float gpu_memory_utilization = 5;
+  uint32 avg_latency_ms = 6;
+}
+
+message ComponentHealth {
+  string name = 1;
+  ServerHealth health = 2;
+  string message = 3;
 }


### PR DESCRIPTION
…es for Rust

## Summary by Sourcery

Add AI server GetStatus RPC implementation and integrate its health/status reporting into the hub metrics and startup lifecycle.

New Features:
- Expose a gRPC GetStatus endpoint on the AI server that reports overall health, component health, supported codecs, uptime, and server configuration.
- Include optional model metadata and system metrics in the GetStatus response when requested by the client.
- Cache the latest AI server status in the hub and expose it via the /health response.
- Invoke GetStatus from the hub before opening the streaming RPC to validate server health and populate cached status.

Enhancements:
- Wire AIModelManager and server lifecycle information into the AI gRPC servicer to back the new status reporting.
- Extend hub metrics to track and clear AI server status across gRPC connect, disconnect, and reconnect events.

Build:
- Update the hub build script to compile protobufs from the relocated proto/naila.proto path.

Tests:
- Add comprehensive unit tests for the GetStatus RPC covering healthy, degraded, and unhealthy states, model info, metrics reporting, and behavior when no manager or server info are configured.
- Extend the hub loopback test service to implement a minimal GetStatus for exercising the new client behavior.