### PR TITLE
Voice/streaming

### DIFF
--- a/ai-server/agents/response_generator.py
+++ b/ai-server/agents/response_generator.py
@@ -36,6 +36,16 @@ class ResponseGenerator(BaseAgent):
         context = state.get("context", {})
         conversation_history = state.get("conversation_history", [])
         confidence = state.get("confidence", 1.0)
+        # ── MULTI-DEVICE NOTE ─────────────────────────────────────────────
+        # device_id is the SOURCE of the request today (one user, one device).
+        # Multi-room features will eventually need to also carry TARGET device(s)
+        # for the response — e.g. "tell <person> in <room>" routes audio to
+        # room B even though the request originated in room A. Suggested
+        # extension: state.get("target_device_ids") returning a list, defaulting
+        # to [device_id] so single-device behavior is unchanged. The audio
+        # delivery callback (further down) is the seam where routing actually
+        # happens.
+        # ─────────────────────────────────────────────────────────────────
         device_id = state.get("device_id", "")
         visual_context = state.get("visual_context")
 
@@ -154,6 +164,22 @@ class ResponseGenerator(BaseAgent):
         )
         return state
 
+    def _augment_query_with_visual(
+        self, query: str, visual_context: Optional[Dict[str, Any]]
+    ) -> str:
+        """Prepend visual context to the user's query when available.
+
+        Used by both the streaming and non-streaming LLM paths so changes to
+        the augmentation format (extra fields, different wording) only need
+        to land in one place.
+        """
+        if not visual_context:
+            return query
+        visual_info = f"Visual context: {visual_context.get('description', '')}"
+        if visual_context.get("object_counts"):
+            visual_info += f" Objects detected: {visual_context['object_counts']}"
+        return f"{visual_info}\n\nUser query: {query}"
+
     async def _stream_response_to_audio(
         self,
         query: str,
@@ -173,15 +199,9 @@ class ResponseGenerator(BaseAgent):
         Returns "" if the stream produced no text (caller should fall back to the
         non-streaming path).
         """
-        # Augment with visual context if present (matches non-streaming path).
-        augmented_query = query
-        if visual_context:
-            visual_info = f"Visual context: {visual_context.get('description', '')}"
-            if visual_context.get("object_counts"):
-                visual_info += f" Objects detected: {visual_context['object_counts']}"
-            augmented_query = f"{visual_info}\n\nUser query: {query}"
-
-        messages = self.llm_service.build_chat_messages(augmented_query, history)
+        messages = self.llm_service.build_chat_messages(
+            self._augment_query_with_visual(query, visual_context), history,
+        )
         sentences: List[str] = []
         # One-sentence lookahead so we can mark only the last delivered chunk
         # is_final=True. Mirrors the lookahead in _grpc_audio_delivery: when a
@@ -189,6 +209,15 @@ class ResponseGenerator(BaseAgent):
         # whatever is still pending at end-of-stream gets is_final=True.
         pending_sentence: Optional[str] = None
 
+        # ── MULTI-DEVICE NOTE ─────────────────────────────────────────────
+        # `audio_delivery` is currently a single callback bound to one device's
+        # gRPC stream. When multi-room features land (cross-room messaging,
+        # spatial response routing, broadcasts), this signature will need to
+        # carry routing intent — likely a list of (device_id, callback) pairs
+        # or a router object the caller provides. The is_final lookahead below
+        # is per-stream and would need to be tracked per-device once one
+        # response can fan out to multiple devices simultaneously.
+        # ─────────────────────────────────────────────────────────────────
         async def _deliver(sentence: str, is_final: bool) -> None:
             try:
                 audio_data = await self.tts_service.synthesize(sentence, output_format=output_format)
@@ -301,16 +330,9 @@ class ResponseGenerator(BaseAgent):
         if not self.llm_service or not self.llm_service.is_ready:
             return ""
 
-        # Augment query with visual context if available
-        augmented_query = query
-        if visual_context:
-            visual_info = f"Visual context: {visual_context.get('description', '')}"
-            if visual_context.get("object_counts"):
-                visual_info += f" Objects detected: {visual_context['object_counts']}"
-            augmented_query = f"{visual_info}\n\nUser query: {query}"
-
-        # Build chat messages with history
-        messages = self.llm_service.build_chat_messages(augmented_query, history)
+        messages = self.llm_service.build_chat_messages(
+            self._augment_query_with_visual(query, visual_context), history,
+        )
 
         last_exception = None
         for attempt in range(1, max_retries + 1):

--- a/ai-server/agents/response_generator.py
+++ b/ai-server/agents/response_generator.py
@@ -42,20 +42,76 @@ class ResponseGenerator(BaseAgent):
         # Check LLM readiness dynamically
         use_llm = self.llm_service is not None and self.llm_service.is_ready
 
-        # Generate context-aware response
-        response = await self._generate_response(
-            intent, processed_text, context, conversation_history, confidence, use_llm=use_llm, visual_context=visual_context
+        # Audio output is needed when:
+        # - gRPC transport (audio is the primary output)
+        # - MQTT with audio input (device sent audio, expects audio back)
+        needs_audio = (
+            configurable.get("transport") == "grpc"
+            or state.get("input_type") == "audio"
         )
-        
+        audio_delivery = configurable.get("audio_delivery")
+        output_format = "raw" if configurable.get("transport") == "grpc" else None
+        tts_ready = self.tts_service is not None and self.tts_service.is_ready
+
+        # Streaming path: synthesize and deliver audio sentence-by-sentence as
+        # the LLM generates, instead of waiting for the full response. Brings
+        # time-to-first-audio down to ~first-sentence-LLM + first-sentence-TTS
+        # regardless of total response length. Only viable when:
+        #   - LLM is available (streaming endpoint exists only on the LLM path)
+        #   - audio is needed and the delivery callback is set up
+        #   - confidence is high enough that we'd use LLM anyway
+        #   - no short-circuit visual response (those are pre-canned text)
+        visual_short_circuit = bool(
+            visual_context and (visual_context.get("answer") or visual_context.get("description"))
+        )
+        can_stream = (
+            use_llm
+            and needs_audio
+            and audio_delivery is not None
+            and tts_ready
+            and not visual_short_circuit
+            and confidence >= 0.3
+        )
+
+        response = ""
+        streamed = False
+        if can_stream:
+            try:
+                response = await self._stream_response_to_audio(
+                    processed_text,
+                    conversation_history,
+                    visual_context,
+                    audio_delivery,
+                    output_format,
+                )
+                streamed = bool(response)
+            except Exception as e:
+                self.logger.warning(
+                    "streaming_path_failed",
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    fallback="non-streaming",
+                )
+                response = ""
+
+        if not response:
+            # Non-streaming fallback: visual short-circuit, low confidence,
+            # streaming-disabled, or streaming returned no text.
+            response = await self._generate_response(
+                intent, processed_text, context, conversation_history, confidence,
+                use_llm=use_llm, visual_context=visual_context,
+            )
+
         # Add response metadata
         response_metadata = {
             "intent": intent,
             "confidence": confidence,
             "generation_time_ms": int((time.time() - start_time) * 1000),
             "context_used": bool(context.get("recent_exchanges")),
-            "device_id": device_id
+            "device_id": device_id,
+            "streamed": streamed,
         }
-        
+
         # Update conversation history
         history_entry = {
             "user": processed_text,
@@ -63,37 +119,27 @@ class ResponseGenerator(BaseAgent):
             "timestamp": state.get("timestamp", ""),
             "metadata": response_metadata
         }
-        
+
         conversation_history.append(history_entry)
-        
+
         # Update state
         state["response_text"] = response
         state["conversation_history"] = conversation_history[-10:]  # Keep last 10
         state["response_metadata"] = response_metadata
 
-        # Synthesize audio only when needed:
-        # - gRPC transport: always (audio is the primary output)
-        # - MQTT with audio input: yes (device sent audio, expects audio back)
-        # - MQTT with text input: skip (text-only round trip, no need to wait for TTS)
-        needs_audio = (
-            configurable.get("transport") == "grpc"
-            or state.get("input_type") == "audio"
-        )
-
-        if needs_audio and self.tts_service and self.tts_service.is_ready:
+        # Non-streaming TTS delivery — only fires when the streaming path didn't
+        # already deliver audio. Streaming handles its own TTS synthesis and
+        # callback invocations sentence-by-sentence.
+        if not streamed and needs_audio and tts_ready:
             try:
-                output_format = "raw" if configurable.get("transport") == "grpc" else None
                 audio_data = await self.tts_service.synthesize(response, output_format=output_format)
-
-                audio_delivery = configurable.get("audio_delivery")
                 if audio_delivery:
                     await audio_delivery(audio_data, response, is_final=True)
-
                 state["response_audio"] = audio_data
                 self.logger.debug(
                     "audio_synthesized",
                     duration_ms=audio_data.duration_ms,
-                    format=audio_data.format
+                    format=audio_data.format,
                 )
             except Exception as e:
                 self.logger.warning("tts_synthesis_failed", error=str(e), error_type=type(e).__name__)
@@ -103,9 +149,83 @@ class ResponseGenerator(BaseAgent):
             "response_generated",
             response=response,
             confidence=round(confidence, 2),
-            generation_time_ms=response_metadata['generation_time_ms']
+            generation_time_ms=response_metadata['generation_time_ms'],
+            streamed=streamed,
         )
         return state
+
+    async def _stream_response_to_audio(
+        self,
+        query: str,
+        history: List[Dict],
+        visual_context: Optional[Dict[str, Any]],
+        audio_delivery,
+        output_format: Optional[str],
+    ) -> str:
+        """Stream LLM tokens, synthesize sentence-by-sentence, deliver via callback.
+
+        Buffers streamed deltas into complete sentences, fires TTS for each as
+        soon as it's ready, calls ``audio_delivery(audio, sentence, is_final=...)``
+        with ``is_final=False`` for every sentence except the last and ``True`` on
+        the final one. Returns the full accumulated response text so the caller
+        can record it in conversation history.
+
+        Returns "" if the stream produced no text (caller should fall back to the
+        non-streaming path).
+        """
+        # Augment with visual context if present (matches non-streaming path).
+        augmented_query = query
+        if visual_context:
+            visual_info = f"Visual context: {visual_context.get('description', '')}"
+            if visual_context.get("object_counts"):
+                visual_info += f" Objects detected: {visual_context['object_counts']}"
+            augmented_query = f"{visual_info}\n\nUser query: {query}"
+
+        messages = self.llm_service.build_chat_messages(augmented_query, history)
+        sentences: List[str] = []
+        # One-sentence lookahead so we can mark only the last delivered chunk
+        # is_final=True. Mirrors the lookahead in _grpc_audio_delivery: when a
+        # new sentence arrives, the previous one is sent with is_final=False;
+        # whatever is still pending at end-of-stream gets is_final=True.
+        pending_sentence: Optional[str] = None
+
+        async def _deliver(sentence: str, is_final: bool) -> None:
+            try:
+                audio_data = await self.tts_service.synthesize(sentence, output_format=output_format)
+                await audio_delivery(audio_data, sentence, is_final=is_final)
+            except Exception as e:
+                self.logger.warning(
+                    "tts_chunk_synthesis_failed",
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    fragment_chars=len(sentence),
+                )
+
+        try:
+            # LLMService yields complete sentences (segmentation runs on the
+            # producer thread). One audio_delivery call per sentence keeps
+            # asyncio cross-thread chatter low.
+            async for sentence in self.llm_service.generate_chat_stream(messages):
+                sentences.append(sentence)
+                if pending_sentence is not None:
+                    await _deliver(pending_sentence, is_final=False)
+                pending_sentence = sentence
+        except Exception as e:
+            self.logger.warning(
+                "llm_stream_interrupted",
+                error=str(e),
+                error_type=type(e).__name__,
+                sentences_so_far=len(sentences),
+            )
+
+        if pending_sentence is not None:
+            await _deliver(pending_sentence, is_final=True)
+
+        # Reconstruct full text for conversation history. Joining with " "
+        # is a slight whitespace approximation of the original (sentences are
+        # stripped during segmentation) but reads correctly and is what gets
+        # fed back to future LLM turns as past assistant context.
+        return " ".join(sentences).strip()
     
     async def _generate_response(
         self,

--- a/ai-server/pyproject.toml
+++ b/ai-server/pyproject.toml
@@ -17,7 +17,11 @@ dependencies = [
     "langgraph>=1.0.2",
     "llama-cpp-python>=0.3.16",
     "num2words>=0.5.14",
-    "numpy>=2.3.4",
+    # Pinned <2.4 because numba (transitive dep of resampy, used in rpc/service.py
+    # for TTS resampling) doesn't support numpy 2.4 yet. Without this pin a fresh
+    # `uv sync` pulls 2.4.x and the AI server crashes on import with
+    # "Numba needs NumPy 2.3 or less".
+    "numpy>=2.3.4,<2.4",
     "opencv-python>=4.11.0.86",
     "paho-mqtt>=2.1.0",
     "pillow>=12.0.0",

--- a/ai-server/rpc/service.py
+++ b/ai-server/rpc/service.py
@@ -475,15 +475,28 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
         tts_queue: asyncio.Queue = asyncio.Queue(maxsize=32)
         audio_produced = False
 
-        # Pacing state shared across multiple _grpc_audio_delivery calls within
-        # the same utterance. Streaming TTS calls the delivery callback once
-        # per sentence; without shared state, each call would reset its pacing
-        # baseline and either over-deliver (queue overflow at the client) or
-        # restart the silence prepend mid-response.
+        # Per-utterance delivery state shared across every _grpc_audio_delivery
+        # invocation for this utterance. Streaming TTS calls the delivery
+        # callback once per sentence; the state below stays continuous across
+        # those calls so we maintain pacing, sequence numbers, and the Opus
+        # encoder's predictor state through sentence boundaries.
+        #
+        # ── MULTI-DEVICE NOTE ─────────────────────────────────────────────
+        # Today this state is scoped per-utterance within a single gRPC stream
+        # (one device, one conversation). When we add multi-room/multi-device
+        # routing, this state needs to be per (device_id, conversation_id) —
+        # because the same AI server may be delivering different responses to
+        # rooms A and B simultaneously, each with its own pacing baseline,
+        # sequence number, and encoder. Likely shape: a dict keyed by
+        # device_id mapping to one of these state structs, plus a small
+        # registry of tts_queues so the gRPC writer knows which queue to
+        # drain for each outgoing AudioOutput message.
+        # ─────────────────────────────────────────────────────────────────
         delivery_state = {
-            "started": False,             # True once the first call has run
+            "silence_prepended": False,   # True after first audio's silence prepend
             "pacing_start": None,         # monotonic timestamp of frame 0
             "cumulative_seq": 0,          # total Opus frames sent in this utterance
+            "encoder": None,              # libopus encoder, lazy-init on first audio
         }
 
         # Send the first ~200ms (10 frames) as fast as the network allows so
@@ -501,46 +514,57 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
             reduction bug.
 
             May be called multiple times per utterance during streaming TTS
-            (once per sentence). Pacing and the silence prepend coordinate
-            across calls via the captured ``delivery_state``.
+            (once per sentence). Pacing, sequence numbers, the silence prepend,
+            and the Opus encoder all coordinate across calls via the captured
+            ``delivery_state`` so streamed sentences look like one continuous
+            audio stream from the receiver's POV.
             """
-            if not audio_data or not audio_data.audio_bytes:
-                return
-            raw_bytes = audio_data.audio_bytes
-            tts_sample_rate = audio_data.sample_rate
+            has_audio = bool(audio_data and audio_data.audio_bytes)
 
-            # Resample to 48kHz for Opus (WebRTC standard).
-            target_rate = 48000
-            if tts_sample_rate != target_rate:
-                samples = np.frombuffer(raw_bytes, dtype=np.int16).astype(np.float32) / 32768.0
-                resampled = resampy.resample(samples, tts_sample_rate, target_rate)
-                pcm_48k = np.clip(resampled * 32768.0, -32768, 32767).astype(np.int16)
-            else:
-                pcm_48k = np.frombuffer(raw_bytes, dtype=np.int16)
+            pcm_48k: Optional[np.ndarray] = None
+            if has_audio:
+                raw_bytes = audio_data.audio_bytes
+                tts_sample_rate = audio_data.sample_rate
 
-            # Prepend ~100ms of silence ONLY on the first call of an utterance.
-            # The silence gives the receive path (jitter buffer, opus decoder
-            # cold-start, playback callback timing) time to reach steady state
-            # before real audio begins — without it the first ~20-40ms of every
-            # response is clipped. On subsequent streaming calls the pipeline
-            # is already warm so silence would just create dead air between
-            # sentences.
-            if not delivery_state["started"]:
-                lead_in_silence = np.zeros(4800, dtype=np.int16)
-                pcm_48k = np.concatenate([lead_in_silence, pcm_48k])
-                delivery_state["pacing_start"] = time.monotonic()
-                delivery_state["started"] = True
+                # Resample to 48kHz for Opus (WebRTC standard).
+                target_rate = 48000
+                if tts_sample_rate != target_rate:
+                    samples = np.frombuffer(raw_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+                    resampled = resampy.resample(samples, tts_sample_rate, target_rate)
+                    pcm_48k = np.clip(resampled * 32768.0, -32768, 32767).astype(np.int16)
+                else:
+                    pcm_48k = np.frombuffer(raw_bytes, dtype=np.int16)
 
-            # Encode 20ms Opus frames using PyAV.
-            opus_enc = av.CodecContext.create('libopus', 'w')
-            opus_enc.sample_rate = 48000
-            opus_enc.layout = 'mono'
-            opus_enc.format = av.AudioFormat('s16')
-            opus_enc.bit_rate = 64000
-            opus_enc.open()
+                # Prepend ~100ms of silence on the first audio of the utterance.
+                # The silence gives the receive path (jitter buffer, opus decoder
+                # cold-start, playback callback timing) time to reach steady state
+                # before real audio begins — without it the first ~20-40ms of
+                # every response is clipped. On subsequent streaming calls the
+                # pipeline is already warm so silence would just create dead air
+                # between sentences.
+                if not delivery_state["silence_prepended"]:
+                    lead_in_silence = np.zeros(4800, dtype=np.int16)
+                    pcm_48k = np.concatenate([lead_in_silence, pcm_48k])
+                    delivery_state["pacing_start"] = time.monotonic()
+                    delivery_state["silence_prepended"] = True
 
-            frame_size = FRAME_SIZE
-            frame_duration_s = FRAME_DURATION_S
+            # Lazy-init the libopus encoder on first audio. Reused across every
+            # streaming sentence in the utterance, then flushed and dropped on
+            # the final call. Reuse saves ~5-10ms of libopus init per chunk
+            # (small per-call but adds up across concurrent multi-device
+            # streams) and keeps the predictor state continuous across
+            # sentence boundaries — the first frame of each new sentence
+            # encodes against valid history instead of a zero-state cold start.
+            if has_audio and delivery_state["encoder"] is None:
+                enc = av.CodecContext.create('libopus', 'w')
+                enc.sample_rate = 48000
+                enc.layout = 'mono'
+                enc.format = av.AudioFormat('s16')
+                enc.bit_rate = 64000
+                enc.open()
+                delivery_state["encoder"] = enc
+
+            opus_enc = delivery_state["encoder"]
             pacing_start = delivery_state["pacing_start"]
 
             # Opus is a buffered encoder: encode(frame) may yield 0+ packets,
@@ -548,11 +572,11 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
             # loop which packet will be the actual last one, so we hold a
             # one-packet lookahead — the previous packet flushes out as
             # is_final=False once we have a successor, and only the truly
-            # final packet (after the encoder is fully flushed) carries
-            # is_final=is_final. Without this, multiple packets ended up
-            # tagged is_final=True (the last in-loop packet plus every flush
-            # packet), which silently violated the "last frame of this
-            # response" contract documented in hub::audio.
+            # final packet of the utterance carries is_final=True. Without
+            # this, multiple packets ended up tagged is_final=True (the last
+            # in-loop packet plus every flush packet), which silently violated
+            # the "last frame of this response" contract documented in
+            # hub::audio.
             pending: Optional[bytes] = None
 
             async def _send_packet(payload: bytes, final: bool) -> None:
@@ -569,33 +593,49 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
                     final_stt=transcription if seq == 0 else "",
                 ))
                 delivery_state["cumulative_seq"] = seq + 1
-                if delivery_state["cumulative_seq"] > INITIAL_BURST_FRAMES:
-                    target = pacing_start + delivery_state["cumulative_seq"] * frame_duration_s
+                if (
+                    delivery_state["cumulative_seq"] > INITIAL_BURST_FRAMES
+                    and pacing_start is not None
+                ):
+                    target = pacing_start + delivery_state["cumulative_seq"] * FRAME_DURATION_S
                     delay = target - time.monotonic()
                     if delay > 0:
                         await asyncio.sleep(delay)
 
-            for i in range(0, len(pcm_48k) - frame_size + 1, frame_size):
-                chunk = pcm_48k[i : i + frame_size]
-                frame = av.AudioFrame.from_ndarray(
-                    chunk.reshape(1, -1), format='s16', layout='mono',
-                )
-                frame.sample_rate = 48000
-                frame.pts = i
-                frame.time_base = Fraction(1, 48000)
+            # Encode this call's audio frames. The encoder retains state across
+            # calls within the utterance (no flush here on intermediate calls).
+            if has_audio and opus_enc is not None and pcm_48k is not None:
+                for i in range(0, len(pcm_48k) - FRAME_SIZE + 1, FRAME_SIZE):
+                    chunk = pcm_48k[i : i + FRAME_SIZE]
+                    frame = av.AudioFrame.from_ndarray(
+                        chunk.reshape(1, -1), format='s16', layout='mono',
+                    )
+                    frame.sample_rate = 48000
+                    frame.pts = i
+                    frame.time_base = Fraction(1, 48000)
 
-                for pkt in opus_enc.encode(frame):
+                    for pkt in opus_enc.encode(frame):
+                        if pending is not None:
+                            await _send_packet(pending, final=False)
+                        pending = bytes(pkt)
+
+            # Flush + drop the encoder ONLY on the final call of the utterance.
+            # Skipping flush on intermediate streaming calls is what gives us
+            # the cross-sentence prediction state continuity. Setting the slot
+            # back to None ensures the next utterance starts with a fresh
+            # encoder — important when the same _process_utterance is reused
+            # for back-to-back conversations.
+            if is_final and delivery_state["encoder"] is not None:
+                for pkt in delivery_state["encoder"].encode(None):
                     if pending is not None:
                         await _send_packet(pending, final=False)
                     pending = bytes(pkt)
+                delivery_state["encoder"] = None
 
-            # Flush encoder
-            for pkt in opus_enc.encode(None):
-                if pending is not None:
-                    await _send_packet(pending, final=False)
-                pending = bytes(pkt)
-
-            # Send the genuinely-last packet (or nothing if no audio was produced).
+            # Send the last packet of THIS call. is_final propagates through:
+            # streaming intermediate calls send their tail with final=False,
+            # the final call sends with final=True (the only packet in the
+            # whole utterance that carries the true is_final).
             if pending is not None:
                 await _send_packet(pending, final=is_final)
 

--- a/ai-server/rpc/service.py
+++ b/ai-server/rpc/service.py
@@ -475,13 +475,34 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
         tts_queue: asyncio.Queue = asyncio.Queue(maxsize=32)
         audio_produced = False
 
+        # Pacing state shared across multiple _grpc_audio_delivery calls within
+        # the same utterance. Streaming TTS calls the delivery callback once
+        # per sentence; without shared state, each call would reset its pacing
+        # baseline and either over-deliver (queue overflow at the client) or
+        # restart the silence prepend mid-response.
+        delivery_state = {
+            "started": False,             # True once the first call has run
+            "pacing_start": None,         # monotonic timestamp of frame 0
+            "cumulative_seq": 0,          # total Opus frames sent in this utterance
+        }
+
+        # Send the first ~200ms (10 frames) as fast as the network allows so
+        # the receiver's jitter buffer fills before real-time pacing kicks in.
+        INITIAL_BURST_FRAMES = 10
+        FRAME_SIZE = 960                  # 20ms at 48kHz
+        FRAME_DURATION_S = FRAME_SIZE / 48000
+
         async def _grpc_audio_delivery(audio_data, text: str, is_final: bool = True):
             """Callback invoked by ResponseGenerator when TTS audio is ready.
 
-            Pre-encodes TTS audio as Opus frames using PyAV and sends them
-            via the audio_opus field. The hub forwards these directly as RTP
-            packets without re-encoding, avoiding the Rust opus crate's
-            amplitude reduction bug.
+            Pre-encodes TTS audio as Opus frames using PyAV and sends them via
+            the audio_opus field. The hub forwards these directly as RTP packets
+            without re-encoding, avoiding the Rust opus crate's amplitude
+            reduction bug.
+
+            May be called multiple times per utterance during streaming TTS
+            (once per sentence). Pacing and the silence prepend coordinate
+            across calls via the captured ``delivery_state``.
             """
             if not audio_data or not audio_data.audio_bytes:
                 return
@@ -497,17 +518,20 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
             else:
                 pcm_48k = np.frombuffer(raw_bytes, dtype=np.int16)
 
-            # Prepend ~100ms of silence so the receive path (jitter buffer,
-            # opus decoder cold-start, playback callback timing) reaches steady
-            # state before real audio begins. Without this the first ~20-40ms
-            # of every TTS response is clipped or muffled — listener hears
-            # "...m here to help" instead of "I'm here to help". 100ms at 48kHz
-            # = 4800 samples = 5 Opus frames; a barely-perceptible extra pause
-            # before the response, much better than a chopped first syllable.
-            lead_in_silence = np.zeros(4800, dtype=np.int16)
-            pcm_48k = np.concatenate([lead_in_silence, pcm_48k])
+            # Prepend ~100ms of silence ONLY on the first call of an utterance.
+            # The silence gives the receive path (jitter buffer, opus decoder
+            # cold-start, playback callback timing) time to reach steady state
+            # before real audio begins — without it the first ~20-40ms of every
+            # response is clipped. On subsequent streaming calls the pipeline
+            # is already warm so silence would just create dead air between
+            # sentences.
+            if not delivery_state["started"]:
+                lead_in_silence = np.zeros(4800, dtype=np.int16)
+                pcm_48k = np.concatenate([lead_in_silence, pcm_48k])
+                delivery_state["pacing_start"] = time.monotonic()
+                delivery_state["started"] = True
 
-            # Encode 20ms Opus frames (960 samples at 48kHz) using PyAV.
+            # Encode 20ms Opus frames using PyAV.
             opus_enc = av.CodecContext.create('libopus', 'w')
             opus_enc.sample_rate = 48000
             opus_enc.layout = 'mono'
@@ -515,25 +539,9 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
             opus_enc.bit_rate = 64000
             opus_enc.open()
 
-            seq = 0
-            frame_size = 960  # 20ms at 48kHz
-            frame_duration_s = frame_size / 48000  # 0.020s
-
-            # Real-time pacing. Without this, the encoder produces ~90 frames
-            # in well under a second and gRPC ships them all to the hub at
-            # full speed; the hub forwards them at full speed to WebRTC; the
-            # audio client receives them in a burst far faster than the 50
-            # frames/sec real-time playback rate. Its bounded speaker queue
-            # then overflows and drops frames mid-response, which sounds like
-            # "speeding up" to the listener.
-            #
-            # Strategy: send the first INITIAL_BURST_FRAMES as fast as we can
-            # so the receiver has a small jitter buffer to start with, then
-            # pace the remainder so each frame leaves at its real-time slot.
-            # The math: target_time for frame N = start + N * 20ms. If we're
-            # ahead, sleep until then; if behind, send immediately.
-            INITIAL_BURST_FRAMES = 10  # 200ms head-start for jitter buffer
-            pacing_start = time.monotonic()
+            frame_size = FRAME_SIZE
+            frame_duration_s = FRAME_DURATION_S
+            pacing_start = delivery_state["pacing_start"]
 
             # Opus is a buffered encoder: encode(frame) may yield 0+ packets,
             # and encode(None) flushes any remaining. We can't know during the
@@ -548,7 +556,7 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
             pending: Optional[bytes] = None
 
             async def _send_packet(payload: bytes, final: bool) -> None:
-                nonlocal seq
+                seq = delivery_state["cumulative_seq"]
                 await tts_queue.put(naila_pb2.AudioOutput(
                     device_id=device_id,
                     conversation_id=conversation_id,
@@ -556,11 +564,13 @@ class NailaAIServicer(naila_pb2_grpc.NailaAIServicer):
                     sample_rate=48000,
                     sequence_num=seq,
                     is_final=final,
+                    # Send the STT transcription only on the very first packet of
+                    # the entire utterance — not the first packet of each chunk.
                     final_stt=transcription if seq == 0 else "",
                 ))
-                seq += 1
-                if seq > INITIAL_BURST_FRAMES:
-                    target = pacing_start + seq * frame_duration_s
+                delivery_state["cumulative_seq"] = seq + 1
+                if delivery_state["cumulative_seq"] > INITIAL_BURST_FRAMES:
+                    target = pacing_start + delivery_state["cumulative_seq"] * frame_duration_s
                     delay = target - time.monotonic()
                     if delay > 0:
                         await asyncio.sleep(delay)

--- a/ai-server/services/llm.py
+++ b/ai-server/services/llm.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import time
-from typing import Dict, List, Optional
+from typing import AsyncIterator, Dict, List, Optional
 
 try:
     from llama_cpp import Llama
@@ -14,6 +14,7 @@ except ImportError:
 from config import llm as llm_config
 from services.base import BaseAIService
 from utils.resource_pool import ResourcePool
+from utils.sentence_buffer import SentenceBuffer
 from utils import get_logger
 
 
@@ -265,6 +266,124 @@ class LLMService(BaseAIService):
         except Exception as e:
             logger.error("llm_generation_failed", error=str(e), error_type=type(e).__name__)
             return ""
+
+    async def generate_chat_stream(
+        self,
+        messages: List[Dict[str, str]],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> AsyncIterator[str]:
+        """Stream LLM output one complete sentence at a time.
+
+        Sentence segmentation runs on the same thread that drives llama-cpp,
+        so cross-thread coordination happens once per sentence (5-10 times
+        per response) instead of once per token (50-100 times). The original
+        token-level approach lost ~13× generation throughput to GIL contention
+        between the producer thread, the asyncio loop, and concurrent TTS work.
+
+        Caller assembles the full response text by joining the yielded
+        sentences if they need it for conversation history.
+        """
+        if not self.is_ready or self.model is None:
+            logger.error("Model not loaded, cannot stream")
+            return
+
+        if self._pool is not None:
+            async with self._pool:
+                async for sentence in self._stream_chat_impl(messages, max_tokens, temperature, top_p):
+                    yield sentence
+        else:
+            async for sentence in self._stream_chat_impl(messages, max_tokens, temperature, top_p):
+                yield sentence
+
+    async def _stream_chat_impl(
+        self,
+        messages: List[Dict[str, str]],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> AsyncIterator[str]:
+        """Run llama-cpp's blocking stream on an executor thread; the producer
+        thread also segments output into sentences so cross-thread asyncio
+        crossings drop from per-token to per-sentence."""
+        start_time = time.time()
+        prompt = self._format_chat_prompt(messages)
+        max_tokens = max_tokens or llm_config.MAX_TOKENS_PER_RESPONSE
+        temperature = temperature or llm_config.DEFAULT_TEMPERATURE
+        top_p = top_p or llm_config.DEFAULT_TOP_P
+
+        if llm_config.LOG_PROMPTS:
+            logger.debug("llm_prompt", prompt=prompt)
+
+        model = self.model
+        assert model is not None
+
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+        _SENTINEL = object()
+
+        def _produce() -> int:
+            """Iterate llama-cpp's blocking stream, segment into sentences on
+            this thread, push complete sentences to the asyncio queue. Returns
+            total token count for performance logging."""
+            buf = SentenceBuffer()
+            tokens = 0
+            try:
+                for chunk in model(
+                    prompt,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=llm_config.DEFAULT_TOP_K,
+                    repeat_penalty=llm_config.REPEAT_PENALTY,
+                    stop=llm_config.STOP_SEQUENCES,
+                    echo=False,
+                    stream=True,
+                ):
+                    if not chunk.get("choices"):
+                        continue
+                    delta = chunk["choices"][0].get("text", "")
+                    if delta:
+                        tokens += 1
+                        for sentence in buf.feed(delta):
+                            loop.call_soon_threadsafe(queue.put_nowait, sentence)
+                tail = buf.flush()
+                if tail:
+                    loop.call_soon_threadsafe(queue.put_nowait, tail)
+            except Exception as e:
+                logger.error("llm_stream_failed", error=str(e), error_type=type(e).__name__)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, (_SENTINEL, tokens))
+            return tokens
+
+        producer = loop.run_in_executor(None, _produce)
+        total_tokens = 0
+        try:
+            while True:
+                item = await queue.get()
+                if isinstance(item, tuple) and item and item[0] is _SENTINEL:
+                    total_tokens = item[1]
+                    break
+                yield item
+        finally:
+            try:
+                await producer
+            except Exception:
+                pass
+
+            inference_time = time.time() - start_time
+            tokens_per_sec = total_tokens / inference_time if inference_time > 0 else 0.0
+            if llm_config.LOG_PERFORMANCE_METRICS:
+                logger.info(
+                    "llm_generation_performance",
+                    inference_time_seconds=round(inference_time, 2),
+                    tokens_generated=total_tokens,
+                    tokens_per_second=round(tokens_per_sec, 1),
+                    streaming=True,
+                )
+            if inference_time > llm_config.WARNING_INFERENCE_TIME_SECONDS:
+                logger.warning("llm_slow_inference", inference_time_seconds=round(inference_time, 2))
 
     def _format_chat_prompt(self, messages: List[Dict[str, str]]) -> str:
         """Format messages into Llama 3.1 chat format"""

--- a/ai-server/utils/sentence_buffer.py
+++ b/ai-server/utils/sentence_buffer.py
@@ -1,0 +1,70 @@
+"""Buffer streamed LLM tokens; emit text at sentence boundaries.
+
+Used by the streaming response path so TTS can begin synthesizing the first
+sentence as soon as the LLM emits it, instead of waiting for the entire
+response to finish generating.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+# Sentence terminators followed by whitespace (or end of buffer at flush).
+# Trailing quote/paren/bracket are absorbed so "She said 'hi.'" stays intact.
+_SENTENCE_END = re.compile(r'[.!?]["\')\]]?(?=\s|$)')
+
+# If no terminator appears within this many chars, force-flush so a runaway
+# LLM (e.g. emitting a giant comma-separated list) doesn't block playback.
+DEFAULT_MAX_BUFFER_CHARS = 240
+
+# Don't emit fragments shorter than this — short sub-sentences (e.g. "Yes.")
+# in mid-stream look like artifacts; the receiver-side jitter buffer also
+# handles tiny chunks poorly.
+DEFAULT_MIN_FRAGMENT_CHARS = 2
+
+
+class SentenceBuffer:
+    """Accumulate streamed tokens, emit complete sentences as they form."""
+
+    def __init__(
+        self,
+        max_buffer_chars: int = DEFAULT_MAX_BUFFER_CHARS,
+        min_fragment_chars: int = DEFAULT_MIN_FRAGMENT_CHARS,
+    ) -> None:
+        self._buf: str = ""
+        self._max_buffer_chars = max_buffer_chars
+        self._min_fragment_chars = min_fragment_chars
+
+    def feed(self, chunk: str) -> List[str]:
+        """Append new tokens; return list of complete sentences ready to send."""
+        if not chunk:
+            return []
+        self._buf += chunk
+        return self._extract_sentences()
+
+    def _extract_sentences(self) -> List[str]:
+        out: List[str] = []
+        while True:
+            match = _SENTENCE_END.search(self._buf)
+            if match is None:
+                # No terminator; force-flush only if buffer is dangerously long.
+                if len(self._buf) >= self._max_buffer_chars:
+                    text = self._buf.strip()
+                    self._buf = ""
+                    if len(text) >= self._min_fragment_chars:
+                        out.append(text)
+                break
+
+            cut = match.end()
+            sentence = self._buf[:cut].strip()
+            self._buf = self._buf[cut:].lstrip()
+            if len(sentence) >= self._min_fragment_chars:
+                out.append(sentence)
+        return out
+
+    def flush(self) -> str:
+        """Return any text remaining in the buffer (call once after stream end)."""
+        rest = self._buf.strip()
+        self._buf = ""
+        return rest if len(rest) >= self._min_fragment_chars else ""

--- a/docs/WSL_SETUP.md
+++ b/docs/WSL_SETUP.md
@@ -112,16 +112,29 @@ bash download_models.sh
 
 ### GPU Acceleration (Optional)
 
-CPU works but is slow (~2 tokens/s). For NVIDIA GPU with WSL2 CUDA:
+CPU works but is slow (~2 tokens/s for the LLM). For NVIDIA GPU with WSL2
+CUDA, rebuild llama-cpp-python with CUDA support:
 
 ```bash
-CMAKE_ARGS="-DGGML_CUDA=on" uv pip install llama-cpp-python \
-  --no-binary llama-cpp-python --force-reinstall --no-cache-dir
+./scripts/rebuild-llama-cuda.sh
 ```
 
-Verify: `python -c "import llama_cpp; print(llama_cpp.llama_supports_gpu_offload())"`
+(Or manually: `CMAKE_ARGS="-DGGML_CUDA=on" uv pip install llama-cpp-python --no-binary llama-cpp-python --force-reinstall --no-cache-dir`)
 
-**Note:** Even with CUDA for the LLM, the STT (faster-whisper) requires cuDNN. If you don't have cuDNN installed, force STT to CPU to avoid crashes (see Section 5).
+Verify: `.venv/bin/python -c "import llama_cpp; print(llama_cpp.llama_supports_gpu_offload())"`
+
+Should print `True` and `ggml_cuda_init: found 1 CUDA devices` lines.
+
+**Important caveat — `uv sync` will silently undo this rebuild.** Any time
+you run `uv sync` (or `uv pip install` something that re-resolves), uv
+replaces your CUDA-built llama-cpp with the PyPI CPU wheel — and the AI
+server silently regresses to ~2 tok/s with no error. After any sync, re-run
+`./scripts/rebuild-llama-cuda.sh`. The `dev-up.sh` script uses
+`uv run --no-sync` for AI server startup specifically to avoid this.
+
+**Note:** Even with CUDA for the LLM, STT (faster-whisper) requires cuDNN.
+If you don't have cuDNN installed, force STT to CPU to avoid crashes
+(see Section 5).
 
 ## 4. Hub Setup
 

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -77,8 +77,12 @@ fi
 # ─────────────────────────────────────────────────────────────────────────────
 
 tmux new-session -d -s "$SESSION" -n ai-server -c "$ROOT/ai-server"
+# `uv run --no-sync` skips uv's implicit dep-resync. Without it, every start
+# overwrites manually-built native packages (e.g. llama-cpp-python compiled
+# with CUDA) by reinstalling the PyPI CPU wheel from uv.lock. Run `uv sync`
+# explicitly when you want to update deps.
 tmux send-keys -t "$SESSION:ai-server" \
-    "source .venv/bin/activate && STT_VAD_FILTER=false STT_DEVICE=cpu STT_COMPUTE_TYPE=int8 uv run python main.py" \
+    "source .venv/bin/activate && STT_VAD_FILTER=false STT_DEVICE=cpu STT_COMPUTE_TYPE=int8 uv run --no-sync python main.py" \
     C-m
 
 tmux new-window -t "$SESSION" -n hub -c "$ROOT/hub"

--- a/scripts/rebuild-llama-cuda.sh
+++ b/scripts/rebuild-llama-cuda.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Rebuild llama-cpp-python from source with CUDA support enabled.
+#
+# Why this exists: the PyPI wheel for llama-cpp-python is CPU-only. Every
+# `uv sync` (or any `uv pip install` that touches the venv) replaces the
+# CUDA-built copy with that CPU wheel and silently regresses LLM throughput
+# from ~50 tok/s back to ~3 tok/s. This script does the rebuild in one
+# command so recovery is trivial.
+#
+# Usage (from repo root or anywhere):
+#   ./scripts/rebuild-llama-cuda.sh
+#
+# Prerequisites:
+#   - CUDA Toolkit installed in WSL (`nvcc --version` should work)
+#   - The ai-server venv exists at ai-server/.venv
+#   - You can spare ~10 minutes for the build
+#
+# After this finishes, restart the AI server so it loads the new build:
+#   tmux send-keys -t naila:ai-server C-c
+#   sleep 5
+#   tmux send-keys -t naila:ai-server "..." Enter
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AI_SERVER_DIR="$(cd "$SCRIPT_DIR/../ai-server" && pwd)"
+
+if ! command -v nvcc >/dev/null 2>&1; then
+    echo "ERROR: nvcc not found. Install the CUDA Toolkit first:" >&2
+    echo "  https://developer.nvidia.com/cuda-toolkit (WSL-Ubuntu version)" >&2
+    echo "Or via apt: see docs/WSL_SETUP.md GPU section." >&2
+    exit 1
+fi
+
+if [[ ! -d "$AI_SERVER_DIR/.venv" ]]; then
+    echo "ERROR: ai-server venv not found at $AI_SERVER_DIR/.venv" >&2
+    echo "Run \`uv sync\` in ai-server/ first." >&2
+    exit 1
+fi
+
+echo "Rebuilding llama-cpp-python with CUDA support..."
+echo "(This takes ~10 minutes — compiles llama.cpp + CUDA kernels from source.)"
+echo
+
+cd "$AI_SERVER_DIR"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+CMAKE_ARGS="-DGGML_CUDA=on" uv pip install llama-cpp-python \
+    --no-binary llama-cpp-python \
+    --force-reinstall \
+    --no-cache-dir
+
+echo
+echo "Verifying GPU support..."
+.venv/bin/python -c "
+import llama_cpp
+ok = llama_cpp.llama_supports_gpu_offload()
+if ok:
+    print('  llama_supports_gpu_offload(): True  — rebuild succeeded')
+else:
+    print('  llama_supports_gpu_offload(): False — rebuild did NOT pick up CUDA')
+    raise SystemExit(1)
+"
+
+echo
+echo "Done. Restart the AI server to pick up the new build."
+echo "  tmux send-keys -t naila:ai-server C-c"
+echo "  sleep 5"
+echo "  tmux send-keys -t naila:ai-server \"source .venv/bin/activate && \\"
+echo "    STT_VAD_FILTER=false STT_DEVICE=cpu STT_COMPUTE_TYPE=int8 \\"
+echo "    uv run --no-sync python main.py\" Enter"


### PR DESCRIPTION
Sped up the latency on the audio loop with full streaming using CUDA. The laptop still struggles both on latency and queue overload without a GPU. Latency between input and first response went from 11 seconds to 2 seconds. Room for improvement but for the entire loop running on one system it doesn't make much sense to keep pushing.

## Summary by Sourcery

Introduce low-latency, sentence-level streaming of LLM responses to TTS audio, improve gRPC audio pacing, and add CUDA rebuild tooling and documentation for faster GPU-backed LLM performance.

New Features:
- Add a streaming response path that sends sentence-level audio chunks while the LLM is still generating, with fallback to the existing non-streaming path.
- Expose a sentence-buffered streaming API on the LLM service that yields complete sentences for downstream TTS and delivery.

Enhancements:
- Refine gRPC audio delivery to coordinate pacing and silence lead-in across multiple chunks, preventing clipped openings and queue overflows during streaming TTS.
- Record whether a response was streamed in response metadata and logs for observability.
- Constrain numpy to a version compatible with numba to avoid runtime import failures.
- Update dev startup to avoid implicit dependency resyncs that would overwrite CUDA-optimized builds.

Build:
- Add a helper script to rebuild llama-cpp-python with CUDA support and verify GPU offload is enabled.

Documentation:
- Expand WSL GPU setup docs with CUDA rebuild instructions, verification steps, and caveats about uv sync downgrading llama-cpp GPU support.